### PR TITLE
[수정] terraform api 수정 및 tf 파일 관리

### DIFF
--- a/app/controllers/terraform_controller.go
+++ b/app/controllers/terraform_controller.go
@@ -37,7 +37,13 @@ func MergeEnvTf(c *fiber.Ctx) error {
 		})
 	}
 
-	email := c.Params("email")
+	email, err := utils.GetEmailFromToken(c)
+	if err != nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": true,
+			"msg":   err,
+		})
+	}
 	userFolderPath := filepath.Join("usertf", email)
 
 	err = services.InitializeFolder(userFolderPath)
@@ -96,7 +102,13 @@ func DestroyEnv(c *fiber.Ctx) error {
 		})
 	}
 
-	email := c.Params("email")
+	email, err := utils.GetEmailFromToken(c)
+	if err != nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": true,
+			"msg":   err,
+		})
+	}
 	userFolderPath := filepath.Join("usertf", email)
 
 	err = services.DestroyTerraform(userFolderPath)

--- a/app/controllers/terraform_controller.go
+++ b/app/controllers/terraform_controller.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Create a user env tf
-// @Router /v1/terraform/merge/{email} [post]
+// @Router /v1/terraform/usertf [post]
 func MergeEnvTf(c *fiber.Ctx) error {
 	now := time.Now().Unix()
 	claims, err := utils.ExtractTokenMetadata(c)
@@ -64,15 +64,22 @@ func MergeEnvTf(c *fiber.Ctx) error {
 		})
 	}
 
+	err = services.ApplyTerraform(userFolderPath)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": true,
+			"msg":   err,
+		})
+	}
+
 	return c.Status(fiber.StatusOK).JSON(fiber.Map{
 		"error": false,
-		"msg":   "merge user env tf success",
+		"msg":   "Successful creation of the user's tf files environment",
 	})
 }
 
-// Apply user env's tf
-// @Router /v1/terraform/apply/{email} [post]
-func ApplyEnvTf(c *fiber.Ctx) error {
+// @Router /v1/terraform/destroy [post]
+func DestroyEnv(c *fiber.Ctx) error {
 	now := time.Now().Unix()
 	claims, err := utils.ExtractTokenMetadata(c)
 	if err != nil {
@@ -88,8 +95,11 @@ func ApplyEnvTf(c *fiber.Ctx) error {
 			"msg":   "unauthorized, check expiration time of your token",
 		})
 	}
+
 	email := c.Params("email")
-	result, err := services.ApplyTerraform(email)
+	userFolderPath := filepath.Join("usertf", email)
+
+	err = services.DestroyTerraform(userFolderPath)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": true,
@@ -99,6 +109,6 @@ func ApplyEnvTf(c *fiber.Ctx) error {
 
 	return c.Status(fiber.StatusOK).JSON(fiber.Map{
 		"error": false,
-		"msg":   result,
+		"msg":   "successful env destruction",
 	})
 }

--- a/app/services/terraform_service.go
+++ b/app/services/terraform_service.go
@@ -142,7 +142,11 @@ func CreateTfvars(userFolderPath string, data []map[string]interface{}) error {
 		// Process variables
 		for key, value := range itemData {
 			if name := fmt.Sprintf("%s_%s", itemType, key); variables[name] != nil {
-				variables[name] = value
+				if i, ok := value.([]interface{}); ok {
+					variables[name] = toStringSlice(i)
+				} else {
+					variables[name] = value
+				}
 			}
 		}
 
@@ -209,6 +213,16 @@ func CreateTfvars(userFolderPath string, data []map[string]interface{}) error {
 	}
 
 	return nil
+}
+
+func toStringSlice(slice []interface{}) []string {
+	result := make([]string, 0)
+	for _, item := range slice {
+		if str, ok := item.(string); ok {
+			result = append(result, str)
+		}
+	}
+	return result
 }
 
 func calcSubnet(req *models.SubnetRequest) []string {

--- a/app/services/terraform_service.go
+++ b/app/services/terraform_service.go
@@ -19,6 +19,7 @@ import (
 var subnetList []map[string]interface{}
 
 func InitializeFolder(folderPath string) error {
+	subnetList = subnetList[:0]
 	err := os.RemoveAll(folderPath)
 	if err != nil {
 		return err
@@ -167,8 +168,8 @@ func CreateTfvars(userFolderPath string, data []map[string]interface{}) error {
 		}
 
 		// Process user-data
-		if itemData["user-data"] != nil {
-			err = createFile(userFolderPath, "user-data.sh", []byte(itemData["user-data"].(string)))
+		if itemData["user_data"] != nil {
+			err = createFile(userFolderPath, "user-data.sh", []byte(itemData["user_data"].(string)))
 			if err != nil {
 				return err
 			}
@@ -244,7 +245,7 @@ func calcSubnet(req *models.SubnetRequest) []string {
 
 func subnetDepend(parentId string) (string, int, int) {
 	tp, start, end := "", -1, -1
-	for idx, sub := range append(subnetList) {
+	for idx, sub := range subnetList {
 		if sub["parent"] == parentId {
 			if start == -1 {
 				tp = sub["type"].(string)

--- a/pkg/routes/private_routes.go
+++ b/pkg/routes/private_routes.go
@@ -15,7 +15,7 @@ func PrivateRoutes(a *fiber.App) {
 	route.Post("/login/refresh", middleware.JWTProtected(), controllers.UserRefresh)
 	route.Post("/logout", middleware.JWTProtected(), controllers.UserSignOut)
 	route.Post("/terraform/usertf", middleware.JWTProtected(), controllers.MergeEnvTf)
-	route.Post("/terraform/apply", middleware.JWTProtected(), controllers.ApplyEnvTf)
+	route.Post("/terraform/destroy", middleware.JWTProtected(), controllers.DestroyEnv)
 	route.Post("/s3/upload", middleware.JWTProtected(), controllers.UploadHandler)
 	route.Get("/s3/download", middleware.JWTProtected(), controllers.DownloadHandler)
 	route.Post("/user/key", middleware.JWTProtected(), controllers.UserKeySave)

--- a/platform/terraform/alb/main.tf
+++ b/platform/terraform/alb/main.tf
@@ -8,7 +8,7 @@ module "alb" {
   load_balancer_type = "application"
 
   vpc_id          = module.vpc.vpc_id
-  subnets         = module.vpc.public_subnets
+  subnets         = var.alb_subnet
   security_groups = [module.alb_sg.security_group_id]
   internal        = false
 

--- a/platform/terraform/alb/main.tf
+++ b/platform/terraform/alb/main.tf
@@ -3,13 +3,13 @@ module "alb" {
   source  = "terraform-aws-modules/alb/aws"
   version = "~> 8.0"
 
-  name = "terramino"
+  name = "tc-alb"
 
   load_balancer_type = "application"
 
   vpc_id          = module.vpc.vpc_id
   subnets         = module.vpc.public_subnets
-  security_groups = [module.terramino_lb.security_group_id]
+  security_groups = [module.alb_sg.security_group_id]
   internal        = false
 
   http_tcp_listeners = [
@@ -21,21 +21,8 @@ module "alb" {
   ]
 
   target_groups = [{
-    name             = "learn-asg-terramino"
+    name             = "Terraform-Canvas ALB"
     backend_port     = 80
     backend_protocol = "HTTP"
   }]
-}
-resource "aws_autoscaling_attachment" "terramino" {
-  autoscaling_group_name = module.asg.autoscaling_group_id
-  lb_target_group_arn    = module.alb.target_group_arns[0]
-}
-
-module "terramino_instance" {
-  source = "terraform-aws-modules/security-group/aws//modules/http-80"
-
-  name   = "learn-asg-terramino-instance"
-  vpc_id = module.vpc.vpc_id
-
-  ingress_with_source_security_group_id = module.terramino_lb.security_group_id
 }

--- a/platform/terraform/alb/variables.tf
+++ b/platform/terraform/alb/variables.tf
@@ -1,0 +1,3 @@
+variable "alb_subnet" {
+  type = list(any)
+}

--- a/platform/terraform/asg/main.tf
+++ b/platform/terraform/asg/main.tf
@@ -6,7 +6,7 @@ module "asg" {
   min_size            = var.asg_min_size
   max_size            = var.asg_max_size
   desired_capacity    = var.asg_desired_capacity
-  vpc_zone_identifier = module.vpc.private_subnets
+  vpc_zone_identifier = var.asg_private
 
   launch_template_name = "learn-terraform-aws-asg-"
   use_name_prefix      = true

--- a/platform/terraform/asg/main.tf
+++ b/platform/terraform/asg/main.tf
@@ -2,7 +2,7 @@
 module "asg" {
   source = "terraform-aws-modules/autoscaling/aws"
 
-  name                = "terramino"
+  name                = "tc-asg"
   min_size            = var.asg_min_size
   max_size            = var.asg_max_size
   desired_capacity    = var.asg_desired_capacity
@@ -10,23 +10,19 @@ module "asg" {
 
   launch_template_name = "learn-terraform-aws-asg-"
   use_name_prefix      = true
-  image_id             = data.aws_ami.amazon-linux.id
+  image_id             = var.asg_image_id
   instance_type        = var.asg_instance_type
   user_data            = file("user-data.sh")
-  security_groups      = [module.terramino_instance.security_group_id]
+  security_groups      = [module.asg_ssg.security_group_id]
 
   tags = {
     key                 = "Name"
-    value               = "HashiCorp Learn ASG - Terramino"
+    value               = "Terraform-Canvas ASG"
     propagate_at_launch = true
   }
 }
 
-module "terramino_lb" {
-  source = "terraform-aws-modules/security-group/aws//modules/http-80"
-
-  name   = "learn-asg-terramino-lb"
-  vpc_id = module.vpc.vpc_id
-
-  ingress_cidr_blocks = ["0.0.0.0/0"]
+resource "aws_autoscaling_attachment" "asg_alb" {
+  autoscaling_group_name = module.asg.autoscaling_group_id
+  lb_target_group_arn    = module.alb.target_group_arns[0]
 }

--- a/platform/terraform/asg/variables.tf
+++ b/platform/terraform/asg/variables.tf
@@ -17,3 +17,7 @@ variable "asg_desired_capacity" {
 variable "asg_image_id" {
   type = string
 }
+
+variable "asg_image_id" {
+  type = string
+}

--- a/platform/terraform/asg/variables.tf
+++ b/platform/terraform/asg/variables.tf
@@ -21,3 +21,7 @@ variable "asg_image_id" {
 variable "asg_image_id" {
   type = string
 }
+
+variable "asg_subnet" {
+  type = list(any)
+}

--- a/platform/terraform/sg/main.tf
+++ b/platform/terraform/sg/main.tf
@@ -1,0 +1,22 @@
+module "asg_ssg" {
+  source = "terraform-aws-modules/security-group/aws"
+  name   = "asg_soucesg_sg"
+  vpc_id = module.vpc.vpc_id
+
+  computed_ingress_with_source_security_group_id = [
+    {
+      rule                     = "http-80-tcp"
+      source_security_group_id = module.alb_sg.security_group_id
+    }
+  ]
+  number_of_computed_ingress_with_source_security_group_id = 1
+}
+
+module "alb_sg" {
+  source = "terraform-aws-modules/security-group/aws//modules/http-80"
+
+  name   = "alb_cidr_sg"
+  vpc_id = module.vpc.vpc_id
+
+  ingress_cidr_blocks = ["0.0.0.0/0"]
+}

--- a/platform/terraform/version/versions.tf
+++ b/platform/terraform/version/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.29"
+    }
+  }
+}

--- a/platform/terraform/vpc/main.tf
+++ b/platform/terraform/vpc/main.tf
@@ -1,13 +1,4 @@
 #vpc
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "zone-name"
-    values = ["ap-northeast-2a", "ap-northeast-2c"]
-  }
-}
-
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "4.0.1"
@@ -15,7 +6,7 @@ module "vpc" {
   name = var.vpc_name
   cidr = var.vpc_cidr
 
-  azs                  = data.aws_availability_zones.available.names
+  azs                  = var.vpc_azs
   private_subnets      = var.vpc_privatesubnet
   public_subnets       = var.vpc_publicsubnet
   enable_dns_hostnames = true

--- a/platform/terraform/vpc/main.tf
+++ b/platform/terraform/vpc/main.tf
@@ -1,6 +1,11 @@
-# vpc
+#vpc
 data "aws_availability_zones" "available" {
   state = "available"
+
+  filter {
+    name   = "zone-name"
+    values = ["ap-northeast-2a", "ap-northeast-2c"]
+  }
 }
 
 module "vpc" {
@@ -18,14 +23,4 @@ module "vpc" {
 
   enable_nat_gateway = true
   single_nat_gateway = false
-}
-
-data "aws_ami" "amazon-linux" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn-ami-hvm-*-x86_64-ebs"]
-  }
 }

--- a/platform/terraform/vpc/variables.tf
+++ b/platform/terraform/vpc/variables.tf
@@ -2,6 +2,10 @@ variable "vpc_name" {
   type = string
 }
 
+variable "vpc_azs" {
+  type = list(any)
+}
+
 variable "vpc_cidr" {
   type = string
 }


### PR DESCRIPTION
## Description

- [x]  tf 파일 생성 api와 실행 api 합치기
- [x]  asg main.tf 수정
- [x]  보안그룹 tf 폴더 분리하기
- [x] etc 파일(version tf, user-data.sh,,,) 생성 함수 추가
- [x] subnet 종속성을 위한 서브넷 처리 함수 추가

## Related Issue

close #20 

## Additional
- 보안 그룹의 유연성 및 재사용성 개선 필요 (모듈 이름 및 인그레스 종류에 따른 분류)
- 아키텍처 다양성 확장에 따라 리소스 폴더 분리 체계화 필요 
- subnetDepend의 경우 resource case에 따라 처리할려 했으나 인덱스 및 각 case 코드가 복잡해져서 다르게 구현 했어요.
- tf만들 때 for문 하나 줄였어요
