### PR TITLE
[수정] Auto Scaling Group 테라폼 apply 오류 해결

### DIFF
--- a/platform/terraform/alb/main.tf
+++ b/platform/terraform/alb/main.tf
@@ -8,8 +8,8 @@ module "alb" {
   load_balancer_type = "application"
 
   vpc_id          = module.vpc.vpc_id
-  subnets         = var.alb_subnet
-  security_groups = [module.alb_sg.security_group_id]
+  subnets         = var.alb_subnet_type == "privatesubnet" ? [for i in range(var.asg_subnet_count[0], var.asg_subnet_count[1]) : module.vpc.private_subnets[i]] : [for i in range(var.asg_subnet_count[0], var.asg_subnet_count[1]) : module.vpc.public_subnets[i]]
+  security_groups = [aws_security_group.alb_sg.id]
   internal        = false
 
   http_tcp_listeners = [
@@ -21,8 +21,18 @@ module "alb" {
   ]
 
   target_groups = [{
-    name             = "Terraform-Canvas ALB"
+    name             = "Terraform-Canvas-ALB"
     backend_port     = 80
     backend_protocol = "HTTP"
+
+    health_check = {
+      path                = "/"
+      protocol            = "HTTP"
+      matcher             = "200"
+      interval            = 120
+      timeout             = 60
+      healthy_threshold   = 2
+      unhealthy_threshold = 2
+    }
   }]
 }

--- a/platform/terraform/alb/variables.tf
+++ b/platform/terraform/alb/variables.tf
@@ -1,3 +1,9 @@
-variable "alb_subnet" {
-  type = list(any)
+variable "alb_subnet_count" {
+  type    = list(number)
+  default = [0, 2]
+}
+
+variable "alb_subnet_type" {
+  type    = string
+  default = "publicsubnet"
 }

--- a/platform/terraform/asg/main.tf
+++ b/platform/terraform/asg/main.tf
@@ -2,18 +2,20 @@
 module "asg" {
   source = "terraform-aws-modules/autoscaling/aws"
 
-  name                = "tc-asg"
-  min_size            = var.asg_min_size
-  max_size            = var.asg_max_size
-  desired_capacity    = var.asg_desired_capacity
-  vpc_zone_identifier = var.asg_private
+  name                      = "tc-asg"
+  min_size                  = var.asg_min_size
+  max_size                  = var.asg_max_size
+  desired_capacity          = var.asg_desired_capacity
+  health_check_type         = "ELB"
+  health_check_grace_period = 300
+  vpc_zone_identifier       = var.asg_subnet_type == "privatesubnet" ? [for i in range(var.asg_subnet_count[0], var.asg_subnet_count[1]) : module.vpc.private_subnets[i]] : [for i in range(var.asg_subnet_count[0], var.asg_subnet_count[1]) : module.vpc.public_subnets[i]]
 
   launch_template_name = "learn-terraform-aws-asg-"
   use_name_prefix      = true
   image_id             = var.asg_image_id
   instance_type        = var.asg_instance_type
-  user_data            = file("user-data.sh")
-  security_groups      = [module.asg_ssg.security_group_id]
+  user_data            = base64encode(file("user-data.sh"))
+  security_groups      = [aws_security_group.asg_ssg.id]
 
   tags = {
     key                 = "Name"

--- a/platform/terraform/asg/variables.tf
+++ b/platform/terraform/asg/variables.tf
@@ -1,27 +1,33 @@
 variable "asg_min_size" {
-  type = number
+  type    = number
+  default = 1
 }
 
 variable "asg_max_size" {
-  type = number
+  type    = number
+  default = 3
 }
 
 variable "asg_instance_type" {
+  type    = string
+  default = "t2.micro"
+}
+
+variable "asg_image_id" {
   type = string
+}
+
+variable "asg_subnet_count" {
+  type    = list(number)
+  default = [0, 2]
+}
+
+variable "asg_subnet_type" {
+  type    = string
+  default = "privatesubnet"
 }
 
 variable "asg_desired_capacity" {
-  type = number
-}
-
-variable "asg_image_id" {
-  type = string
-}
-
-variable "asg_image_id" {
-  type = string
-}
-
-variable "asg_subnet" {
-  type = list(any)
+  type    = number
+  default = 2
 }

--- a/platform/terraform/sg/main.tf
+++ b/platform/terraform/sg/main.tf
@@ -1,22 +1,37 @@
-module "asg_ssg" {
-  source = "terraform-aws-modules/security-group/aws"
-  name   = "asg_soucesg_sg"
+resource "aws_security_group" "asg_ssg" {
+  name   = "asg-sg"
   vpc_id = module.vpc.vpc_id
 
-  computed_ingress_with_source_security_group_id = [
-    {
-      rule                     = "http-80-tcp"
-      source_security_group_id = module.alb_sg.security_group_id
-    }
-  ]
-  number_of_computed_ingress_with_source_security_group_id = 1
+  ingress {
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb_sg.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 
-module "alb_sg" {
-  source = "terraform-aws-modules/security-group/aws//modules/http-80"
-
-  name   = "alb_cidr_sg"
+resource "aws_security_group" "alb_sg" {
+  name   = "alb-cidr-sg"
   vpc_id = module.vpc.vpc_id
 
-  ingress_cidr_blocks = ["0.0.0.0/0"]
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }

--- a/platform/terraform/vpc/variables.tf
+++ b/platform/terraform/vpc/variables.tf
@@ -1,13 +1,11 @@
 variable "vpc_name" {
-  type = string
-}
-
-variable "vpc_azs" {
-  type = list(any)
+  type    = string
+  default = "example-vpc"
 }
 
 variable "vpc_cidr" {
-  type = string
+  type    = string
+  default = "10.0.0.0/16"
 }
 
 variable "vpc_publicsubnet" {
@@ -16,4 +14,9 @@ variable "vpc_publicsubnet" {
 
 variable "vpc_privatesubnet" {
   type = list(any)
+}
+
+variable "vpc_azs" {
+  type    = list(any)
+  default = ["us-east-1a", "us-east-1c"]
 }


### PR DESCRIPTION
## Description

- [x]  underbar(_)가 name에 있는 경우 hyphen(-)로 변경
- [x] user-data.sh 파일 base64encoding 진행
- [x] cidr list가 아닌 vpc module을 참조해서 indexing

## Related Issue

close #35 

## Additional
- **현재 Apply시 ALB 접근에서 502 Bad Gateway error, target group의 인스턴스 unhealthy 등의 문제가 있어서 해결해야 함**
- terraform 내에서 조건문으로, subnet type 선택 후 for문으로 list의 index에 맞게 삽입하는 방식을 사용함
- 보안그룹의 경우 engress랑 몇 설정 부분에서 직접 정의하는게 더 나아서 resource로 정의했음
