### PR TITLE
[수정] command exec 에러 

### DIFF
--- a/app/controllers/s3_controller.go
+++ b/app/controllers/s3_controller.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,7 +30,7 @@ func UploadHandler(c *fiber.Ctx) error {
 		})
 	}
 	email, err := utils.GetEmailFromToken(c)
-	log.Println(email)
+
 	if err != nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 			"error": true,

--- a/app/services/terraform_service.go
+++ b/app/services/terraform_service.go
@@ -346,7 +346,7 @@ func ApplyTerraform(userFolderPath string) error {
 	}
 
 	for _, command := range commands {
-		cmd := exec.Command(command)
+		cmd := exec.Command("bash", "-c", command)
 		err := cmd.Run()
 		if err != nil {
 			return err
@@ -373,7 +373,7 @@ func DestroyTerraform(userFolderPath string) error {
 		return err
 	}
 
-	cmd := exec.Command("terraform destroy -auto-approve")
+	cmd := exec.Command("bash", "-c", "terraform destroy -auto-approve")
 	err = cmd.Run()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

- exec.Command로 명령어 실행시 executable file not found in $path 에러 발생
- [x] bash -c 를 통한 쉘에 반환

## Related Issue

close #62 

## 📎 Additional context

- 추가로 log패키지도 삭제
